### PR TITLE
Mod FX Cleanup; Filter Balance; Start on mod Matrix

### DIFF
--- a/src/chord-memory/chord-memory.h
+++ b/src/chord-memory/chord-memory.h
@@ -42,6 +42,7 @@ struct ConduitChordMemoryConfig
 {
     static constexpr int nParams{sst::conduit::chord_memory::nParams};
     static constexpr bool baseClassProvidesMonoModSupport{true};
+    static constexpr bool usesSpecializedMessages{false};
     using PatchExtension = sst::conduit::shared::EmptyPatchExtension;
     struct DataCopyForUI
     {

--- a/src/clap-event-monitor/clap-event-monitor.h
+++ b/src/clap-event-monitor/clap-event-monitor.h
@@ -44,6 +44,7 @@ struct ConduitClapEventMonitorConfig
 {
     static constexpr int nParams{sst::conduit::clap_event_monitor::nParams};
     static constexpr bool baseClassProvidesMonoModSupport{true};
+    static constexpr bool usesSpecializedMessages{false};
     using PatchExtension = sst::conduit::shared::EmptyPatchExtension;
     struct DataCopyForUI
     {

--- a/src/mts-to-noteexpression/mts-to-noteexpression.h
+++ b/src/mts-to-noteexpression/mts-to-noteexpression.h
@@ -46,6 +46,7 @@ struct ConduitMTSToNoteExpressionConfig
 {
     static constexpr int nParams{sst::conduit::mts_to_noteexpression::nParams};
     static constexpr bool baseClassProvidesMonoModSupport{true};
+    static constexpr bool usesSpecializedMessages{false};
     using PatchExtension = sst::conduit::shared::EmptyPatchExtension;
     struct DataCopyForUI
     {

--- a/src/polysynth/effects-impl.h
+++ b/src/polysynth/effects-impl.h
@@ -50,7 +50,7 @@ struct SharedConfig
     }
     static bool isDeactivated(EffectStorage *, int) { return false; }
     static bool isExtended(EffectStorage *, int) { return false; }
-    static float rand01(GlobalStorage *) { return 0; }
+    static float rand01(GlobalStorage *g) { return g->urd(g->gen); }
     static double sampleRate(GlobalStorage *g) { return g->sampleRate; }
     static double sampleRateInv(GlobalStorage *g) { return g->sampleRateInv; }
     static float noteToPitch(GlobalStorage *g, float note)

--- a/src/polysynth/modmatrix.h
+++ b/src/polysynth/modmatrix.h
@@ -1,8 +1,93 @@
-//
-// Created by Paul Walker on 10/6/23.
-//
+/*
+ * Conduit - a project highlighting CLAP-first development
+ *           and exercising the surge synth team libraries.
+ *
+ * Copyright 2023 Paul Walker and authors in github
+ *
+ * This file you are viewing now is released under the
+ * MIT license as described in LICENSE.md
+ *
+ * The assembled program which results from compiling this
+ * project has GPL3 dependencies, so if you distribute
+ * a binary, the combined work would be a GPL3 product.
+ *
+ * Roughly, that means you are welcome to copy the code and
+ * ideas in the src/ directory, but perhaps not code from elsewhere
+ * if you are closed source or non-GPL3. And if you do copy this code
+ * you will need to replace some of the dependencies. Please see
+ * the discussion in README.md for further information on what this may
+ * mean for you.
+ */
 
-#ifndef CONDUIT_MODMATRIX_H
-#define CONDUIT_MODMATRIX_H
+#ifndef CONDUIT_SRC_POLYSYNTH_MODMATRIX_H
+#define CONDUIT_SRC_POLYSYNTH_MODMATRIX_H
 
-#endif //CONDUIT_MODMATRIX_H
+#include <unordered_map>
+
+namespace sst::conduit::polysynth
+{
+template <typename SourceID, typename TargetID, typename CurveID> struct ModMatrix
+{
+    using matrix_t = ModMatrix<SourceID, TargetID, CurveID>;
+
+    std::unordered_map<SourceID, float *> sourceValues;
+    std::unordered_map<TargetID, float *> targetValues;
+
+    struct EntryDescription
+    {
+        SourceID source;
+        SourceID via;
+        CurveID curveBy;
+        float depth;
+        TargetID target;
+    };
+
+    struct RealizedEntry
+    {
+        float *source;
+        float *via;
+        float *target;
+        float depth;
+
+        void fromEntryDescription(const matrix_t &mat, EntryDescription &d)
+        {
+            {
+                auto se = mat.sourceValues.find(d.source);
+                if (se == mat.sourceValues.end())
+                    source = nullptr;
+                else
+                    source = se->second;
+            }
+            {
+                auto ve = mat.sourceValues.find(d.via);
+                if (ve == mat.sourceValues.end())
+                    via = nullptr;
+                else
+                    via = ve->second;
+            }
+            {
+                auto te = mat.targetValues.find(d.target);
+                if (te == mat.targetValues.end())
+                    target = nullptr;
+                else
+                    target = te->second;
+            }
+            depth = d.depth;
+        }
+
+        void apply()
+        {
+            if (!target)
+                return;
+            if (!source)
+                return;
+            auto v = *source * depth;
+            if (via)
+                v *= *via;
+            *target = v;
+        }
+    };
+};
+} // namespace sst::conduit::polysynth
+
+#endif // CONDUIT_MODMATRIX_H

--- a/src/polysynth/voice.h
+++ b/src/polysynth/voice.h
@@ -100,7 +100,9 @@ struct PolysynthVoice
         LowWSMulti,
         MultiWSLow,
         WSLowMulti,
-        LowMultiWS
+        LowMultiWS,
+        WSPar,
+        ParWS
     } filterRouting;
 
     enum Waveshapers

--- a/src/ring-modulator/ring-modulator.h
+++ b/src/ring-modulator/ring-modulator.h
@@ -45,6 +45,7 @@ struct ConduitRingModulatorConfig
 {
     static constexpr int nParams{sst::conduit::ring_modulator::nParams};
     static constexpr bool baseClassProvidesMonoModSupport{true};
+    static constexpr bool usesSpecializedMessages{false};
     using PatchExtension = sst::conduit::shared::EmptyPatchExtension;
     struct DataCopyForUI
     {


### PR DESCRIPTION
1. ModFX CLeanup: Rate capped at 20hz
2. ModFX Cleanup: Random in place for Flanger 1 works. Addresses #44
3. Advanced Filter Gain Leveling. Closes #45
4. Start on a mod matrix messages
5. Restore the parallel filter routings.