### PR TITLE
Linux VST3 re-folders; update doc and behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,11 +139,24 @@ function(add_to_all)
                     ${coldir}/$<TARGET_PROPERTY:${TGT},MACOSX_BUNDLE_BUNDLE_NAME>.$<TARGET_PROPERTY:${TGT},BUNDLE_EXTENSION>/
                     )
         else()
-            add_custom_command(TARGET ${pn}
-                    POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E make_directory ${coldir}
-                    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${TGT}> ${coldir}
-                    )
+            set(isb FALSE)
+            get_property(isb TARGET ${TGT} PROPERTY CONDUIT_HAS_BUNDLE_STRUCTURE)
+
+            if (${isb})
+                message(STATUS "conduit: Treating ${TGT} as a bundle on linux")
+                add_custom_command(TARGET ${pn}
+                        POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E make_directory ${coldir}
+                        COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_FILE_DIR:${TGT}>/../../../$<TARGET_PROPERTY:${TGT},LIBRARY_OUTPUT_NAME>.$<TARGET_PROPERTY:${TGT},CONDUIT_BUNDLE_SUFFIX>/
+                        ${coldir}/$<TARGET_PROPERTY:${TGT},LIBRARY_OUTPUT_NAME>.$<TARGET_PROPERTY:${TGT},CONDUIT_BUNDLE_SUFFIX>/
+                )
+            else()
+                add_custom_command(TARGET ${pn}
+                        POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E make_directory ${coldir}
+                        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${TGT}> ${coldir}
+                        )
+            endif()
         endif()
     endforeach ()
 endfunction(add_to_all)
@@ -165,13 +178,14 @@ function(make_conduit_standalone)
 endfunction()
 
 
-if (NOT DEFINED CONDUIT_SKIP_STANDALONES)
+if (${CONDUIT_BUILD_STANDALONES})
     make_conduit_standalone(NAME "Polysynth" ID "polysynth")
     make_conduit_standalone(NAME "Polymetric Delay" ID "polymetric-delay")
     make_conduit_standalone(NAME "Ring Modulator" ID "ring-modulator")
     make_conduit_standalone(NAME "Chord Memory" ID "chord-memory")
 endif()
 
+set_target_properties(${PROJECT_NAME}_vst3 PROPERTIES CONDUIT_HAS_BUNDLE_STRUCTURE TRUE CONDUIT_BUNDLE_SUFFIX "vst3")
 add_to_all(TARGETS ${PROJECT_NAME}_clap ${PROJECT_NAME}_vst3)
 if (APPLE)
     add_to_all(TARGETS ${PROJECT_NAME}_auv2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ target_sources(${VST3_TARGET} PRIVATE src/conduit-clap-entry.cpp)
 target_link_libraries(${VST3_TARGET} PRIVATE conduit-impl)
 target_add_vst3_wrapper(TARGET ${VST3_TARGET}
         OUTPUT_NAME "Conduit"
+        SUPPORTS_ALL_NOTE_EXPRESSIONS TRUE
         )
 if (WIN32)
     # Question - do we want this default in the helpers
@@ -185,7 +186,9 @@ if (${CONDUIT_BUILD_STANDALONES})
     make_conduit_standalone(NAME "Chord Memory" ID "chord-memory")
 endif()
 
-set_target_properties(${PROJECT_NAME}_vst3 PROPERTIES CONDUIT_HAS_BUNDLE_STRUCTURE TRUE CONDUIT_BUNDLE_SUFFIX "vst3")
+if (UNIX)
+    set_target_properties(${PROJECT_NAME}_vst3 PROPERTIES CONDUIT_HAS_BUNDLE_STRUCTURE TRUE CONDUIT_BUNDLE_SUFFIX "vst3")
+endif()
 add_to_all(TARGETS ${PROJECT_NAME}_clap ${PROJECT_NAME}_vst3)
 if (APPLE)
     add_to_all(TARGETS ${PROJECT_NAME}_auv2)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cmake --build build --target conduit_all
 
 results in a `Conduit.clap` and `Conduit.vst3` in `build/conduit_products`.
 
-The best way to interact with this project is
+The best way to interact with this project is to reac us via:
 
 1. The `#conduit-dev` channel on surge discord
 2. The `#wrappers` channel on clap discord or

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Experimental Conduit Plugin
 
-This is experimental code. Right now all the DSP and processing is 
-bad. So far this exists to set up the wrapper infrastructure
-and to ponder how to do 'clap-first' development.
+Conduit is still experimental. Things are getting better but lots
+still doesn't work, and a few things only work on Mac. 
+
+You can download the nightly from here, but your best bet is:
 
 ```bash
 git clone https://github.com/surge-synthesizer/conduit
@@ -12,19 +13,14 @@ cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
 cmake --build build --target conduit_all
 ```
 
-results in a `Conduit.clap` and `Conduit.vst3` somewhere
-in your build directory. Changes based on platform right now.
-You can find em.
+results in a `Conduit.clap` and `Conduit.vst3` in `build/conduit_products`.
 
-My todo list is in the BaconPaulTODO.md but is a mess
+The best way to interact with this project is
 
-right now, hmu in the #wrappers channel on clap discord or
-if you really want in #clap-chatter in surge discord
+1. The `#conduit-dev` channel on surge discord
+2. The `#wrappers` channel on clap discord or
+3. Github Issues here
 
-Said DSP and processing are getting incrementally less bad. But this is still 
-primarily an infrastructure project. If you're looking for good plugins this 
-still ain't quite the place. Feel free to try them but don't
-expect things like "all the parameters do something" yet. :)
 
 ## An Important Note about Licensing
 


### PR DESCRIPTION
1. Readme fixed up
2. Dstandalones of by default
3. Linux VST3 in all target stays folder