### PR TITLE
Restructure Desc; some more work on M2 support

### DIFF
--- a/src/chord-memory/chord-memory-editor.cpp
+++ b/src/chord-memory/chord-memory-editor.cpp
@@ -107,8 +107,7 @@ std::unique_ptr<juce::Component> ConduitChordMemory::createEditor()
     uiComms.refreshUIValues = true;
     auto innards =
         std::make_unique<sst::conduit::chord_memory::editor::ConduitChordMemoryEditor>(uiComms);
-    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitChordMemory>>(
-        uiComms, desc.name, desc.id);
+    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitChordMemory>>(uiComms);
     editor->setContentComponent(std::move(innards));
 
     return editor;

--- a/src/chord-memory/chord-memory.cpp
+++ b/src/chord-memory/chord-memory.cpp
@@ -25,20 +25,24 @@
 
 namespace sst::conduit::chord_memory
 {
-const char *features[] = {CLAP_PLUGIN_FEATURE_NOTE_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
-clap_plugin_descriptor desc = {CLAP_VERSION,
-                               "org.surge-synth-team.conduit.chord-memory",
-                               "Conduit Chord Memory",
-                               "Surge Synth Team",
-                               "https://surge-synth-team.org",
-                               "",
-                               "",
-                               sst::conduit::build::FullVersionStr,
-                               "The Conduit Chord Memory is a work in progress",
-                               features};
+const clap_plugin_descriptor *ConduitChordMemoryConfig::getDescription()
+{
+    const char *features[] = {CLAP_PLUGIN_FEATURE_NOTE_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
+    static clap_plugin_descriptor desc = {CLAP_VERSION,
+                                          "org.surge-synth-team.conduit.chord-memory",
+                                          "Conduit Chord Memory",
+                                          "Surge Synth Team",
+                                          "https://surge-synth-team.org",
+                                          "",
+                                          "",
+                                          sst::conduit::build::FullVersionStr,
+                                          "The Conduit Chord Memory is a work in progress",
+                                          features};
+    return &desc;
+}
 
 ConduitChordMemory::ConduitChordMemory(const clap_host *host)
-    : sst::conduit::shared::ClapBaseClass<ConduitChordMemory, ConduitChordMemoryConfig>(&desc, host)
+    : sst::conduit::shared::ClapBaseClass<ConduitChordMemory, ConduitChordMemoryConfig>(host)
 {
     auto autoFlag = CLAP_PARAM_IS_AUTOMATABLE;
     auto steppedFlag = autoFlag | CLAP_PARAM_IS_STEPPED;

--- a/src/chord-memory/chord-memory.cpp
+++ b/src/chord-memory/chord-memory.cpp
@@ -27,7 +27,8 @@ namespace sst::conduit::chord_memory
 {
 const clap_plugin_descriptor *ConduitChordMemoryConfig::getDescription()
 {
-    const char *features[] = {CLAP_PLUGIN_FEATURE_NOTE_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
+    static const char *features[] = {CLAP_PLUGIN_FEATURE_NOTE_EFFECT, CLAP_PLUGIN_FEATURE_DELAY,
+                                     nullptr};
     static clap_plugin_descriptor desc = {CLAP_VERSION,
                                           "org.surge-synth-team.conduit.chord-memory",
                                           "Conduit Chord Memory",
@@ -37,7 +38,7 @@ const clap_plugin_descriptor *ConduitChordMemoryConfig::getDescription()
                                           "",
                                           sst::conduit::build::FullVersionStr,
                                           "The Conduit Chord Memory is a work in progress",
-                                          features};
+                                          &features[0]};
     return &desc;
 }
 

--- a/src/chord-memory/chord-memory.h
+++ b/src/chord-memory/chord-memory.h
@@ -36,7 +36,6 @@
 namespace sst::conduit::chord_memory
 {
 
-extern clap_plugin_descriptor desc;
 static constexpr int nParams = 1;
 
 struct ConduitChordMemoryConfig
@@ -60,7 +59,7 @@ struct ConduitChordMemoryConfig
         std::atomic<bool> isProcessing{false};
     };
 
-    static clap_plugin_descriptor *getDescription() { return &desc; }
+    static const clap_plugin_descriptor *getDescription();
 };
 
 struct ConduitChordMemory

--- a/src/clap-event-monitor/clap-event-monitor-editor.cpp
+++ b/src/clap-event-monitor/clap-event-monitor-editor.cpp
@@ -232,8 +232,7 @@ std::unique_ptr<juce::Component> ConduitClapEventMonitor::createEditor()
     auto innards =
         std::make_unique<sst::conduit::clap_event_monitor::editor::ConduitClapEventMonitorEditor>(
             uiComms);
-    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitClapEventMonitor>>(
-        uiComms, desc.name, desc.id);
+    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitClapEventMonitor>>(uiComms);
     innards->fixedFace = editor->loadFont("Anonymous_Pro/AnonymousPro-Regular.ttf");
     editor->setContentComponent(std::move(innards));
 

--- a/src/clap-event-monitor/clap-event-monitor.cpp
+++ b/src/clap-event-monitor/clap-event-monitor.cpp
@@ -25,21 +25,25 @@
 
 namespace sst::conduit::clap_event_monitor
 {
-const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
-clap_plugin_descriptor desc = {CLAP_VERSION,
-                               "org.surge-synth-team.conduit.clap-event-monitor",
-                               "Conduit Clap Event Monitor",
-                               "Surge Synth Team",
-                               "https://surge-synth-team.org",
-                               "",
-                               "",
-                               sst::conduit::build::FullVersionStr,
-                               "The Conduit ClapEventMonitor is a work in progress",
-                               features};
+const clap_plugin_descriptor *ConduitClapEventMonitorConfig::getDescription()
+{
+    const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
+    static clap_plugin_descriptor desc = {CLAP_VERSION,
+                                          "org.surge-synth-team.conduit.clap-event-monitor",
+                                          "Conduit Clap Event Monitor",
+                                          "Surge Synth Team",
+                                          "https://surge-synth-team.org",
+                                          "",
+                                          "",
+                                          sst::conduit::build::FullVersionStr,
+                                          "The Conduit ClapEventMonitor is a work in progress",
+                                          features};
+    return &desc;
+}
 
 ConduitClapEventMonitor::ConduitClapEventMonitor(const clap_host *host)
     : sst::conduit::shared::ClapBaseClass<ConduitClapEventMonitor, ConduitClapEventMonitorConfig>(
-          &desc, host)
+          host)
 {
     auto autoFlag = CLAP_PARAM_IS_AUTOMATABLE;
     auto steppedFlag = autoFlag | CLAP_PARAM_IS_STEPPED;

--- a/src/clap-event-monitor/clap-event-monitor.cpp
+++ b/src/clap-event-monitor/clap-event-monitor.cpp
@@ -27,7 +27,8 @@ namespace sst::conduit::clap_event_monitor
 {
 const clap_plugin_descriptor *ConduitClapEventMonitorConfig::getDescription()
 {
-    const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
+    static const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_DELAY,
+                                     nullptr};
     static clap_plugin_descriptor desc = {CLAP_VERSION,
                                           "org.surge-synth-team.conduit.clap-event-monitor",
                                           "Conduit Clap Event Monitor",
@@ -37,7 +38,7 @@ const clap_plugin_descriptor *ConduitClapEventMonitorConfig::getDescription()
                                           "",
                                           sst::conduit::build::FullVersionStr,
                                           "The Conduit ClapEventMonitor is a work in progress",
-                                          features};
+                                          &features[0]};
     return &desc;
 }
 

--- a/src/clap-event-monitor/clap-event-monitor.h
+++ b/src/clap-event-monitor/clap-event-monitor.h
@@ -36,8 +36,6 @@
 
 namespace sst::conduit::clap_event_monitor
 {
-
-extern clap_plugin_descriptor desc;
 static constexpr int nParams = 3;
 
 struct ConduitClapEventMonitorConfig
@@ -85,7 +83,7 @@ struct ConduitClapEventMonitorConfig
         }
     };
 
-    static clap_plugin_descriptor *getDescription() { return &desc; }
+    static const clap_plugin_descriptor *getDescription();
 };
 
 struct ConduitClapEventMonitor

--- a/src/conduit-clap-entry.cpp
+++ b/src/conduit-clap-entry.cpp
@@ -23,8 +23,8 @@
  * This file provides the `clap_plugin_entry` entry point required in the DLL for all
  * clap plugins. It also provides the basic functions for the resulting factory class
  * which generates the plugin. In a single plugin case, this really is just plumbing
- * through to expose polysynth::desc and create a polysynth plugin instance using
- * the helper classes.
+ * through to expose polysynth::ConduitPolysynthConfig::getDescription() and create a polysynth
+ * plugin instance using the helper classes.
  *
  * For more information on this mechanism, see include/clap/entry.h
  */
@@ -55,20 +55,21 @@ namespace sst::conduit::pluginentry
 uint32_t clap_get_plugin_count(const clap_plugin_factory *f) { return 7; }
 const clap_plugin_descriptor *clap_get_plugin_descriptor(const clap_plugin_factory *f, uint32_t w)
 {
+    CNDOUT << CNDVAR(w) << std::endl;
     if (w == 0)
-        return &polysynth::desc;
+        return polysynth::ConduitPolysynthConfig::getDescription();
     if (w == 1)
-        return &polymetric_delay::desc;
+        return polymetric_delay::ConduitPolymetricDelayConfig::getDescription();
     if (w == 2)
-        return &chord_memory::desc;
+        return chord_memory::ConduitChordMemoryConfig::getDescription();
     if (w == 3)
-        return &ring_modulator::desc;
+        return ring_modulator::ConduitRingModulatorConfig::getDescription();
     if (w == 4)
-        return &clap_event_monitor::desc;
+        return clap_event_monitor::ConduitClapEventMonitorConfig::getDescription();
     if (w == 5)
-        return &mts_to_noteexpression::desc;
+        return mts_to_noteexpression::ConduitMTSToNoteExpressionConfig::getDescription();
     if (w == 6)
-        return &midi2_sawsynth::desc;
+        return midi2_sawsynth::ConduitMIDI2SawSynthConfig::getDescription();
 
     CNDOUT << "Clap Plugin not found at " << w << std::endl;
     return nullptr;
@@ -77,39 +78,42 @@ const clap_plugin_descriptor *clap_get_plugin_descriptor(const clap_plugin_facto
 static const clap_plugin *clap_create_plugin(const clap_plugin_factory *f, const clap_host *host,
                                              const char *plugin_id)
 {
-    if (strcmp(plugin_id, polysynth::desc.id) == 0)
+    if (strcmp(plugin_id, polysynth::ConduitPolysynthConfig::getDescription()->id) == 0)
     {
         auto p = new polysynth::ConduitPolysynth(host);
         return p->clapPlugin();
     }
-    if (strcmp(plugin_id, polymetric_delay::desc.id) == 0)
+    if (strcmp(plugin_id, polymetric_delay::ConduitPolymetricDelayConfig::getDescription()->id) ==
+        0)
     {
         auto p = new polymetric_delay::ConduitPolymetricDelay(host);
         return p->clapPlugin();
     }
-    if (strcmp(plugin_id, chord_memory::desc.id) == 0)
+    if (strcmp(plugin_id, chord_memory::ConduitChordMemoryConfig::getDescription()->id) == 0)
     {
         auto p = new chord_memory::ConduitChordMemory(host);
         return p->clapPlugin();
     }
-    if (strcmp(plugin_id, ring_modulator::desc.id) == 0)
+    if (strcmp(plugin_id, ring_modulator::ConduitRingModulatorConfig::getDescription()->id) == 0)
     {
         auto p = new ring_modulator::ConduitRingModulator(host);
         return p->clapPlugin();
     }
-    if (strcmp(plugin_id, clap_event_monitor::desc.id) == 0)
+    if (strcmp(plugin_id,
+               clap_event_monitor::ConduitClapEventMonitorConfig::getDescription()->id) == 0)
     {
         auto p = new clap_event_monitor::ConduitClapEventMonitor(host);
         return p->clapPlugin();
     }
 
-    if (strcmp(plugin_id, mts_to_noteexpression::desc.id) == 0)
+    if (strcmp(plugin_id,
+               mts_to_noteexpression::ConduitMTSToNoteExpressionConfig::getDescription()->id) == 0)
     {
         auto p = new mts_to_noteexpression::ConduitMTSToNoteExpression(host);
         return p->clapPlugin();
     }
 
-    if (strcmp(plugin_id, midi2_sawsynth::desc.id) == 0)
+    if (strcmp(plugin_id, midi2_sawsynth::ConduitMIDI2SawSynthConfig::getDescription()->id) == 0)
     {
         auto p = new midi2_sawsynth::ConduitMIDI2SawSynth(host);
         return p->clapPlugin();
@@ -125,38 +129,41 @@ static bool clap_get_auv2_info(const clap_plugin_factory_as_auv2 *factory, uint3
     auto plugin_id = desc->id;
 
     info->au_type[0] = 0; // use the features to determine the type
-    if (strcmp(plugin_id, polysynth::desc.id) == 0)
+    if (strcmp(plugin_id, polysynth::ConduitPolysynthConfig::getDescription()->id) == 0)
     {
         strncpy(info->au_subt, "PlyS", 5);
         return true;
     }
-    if (strcmp(plugin_id, polymetric_delay::desc.id) == 0)
+    if (strcmp(plugin_id, polymetric_delay::ConduitPolymetricDelayConfig::getDescription()->id) ==
+        0)
     {
         strncpy(info->au_subt, "dLay", 5);
         return true;
     }
-    if (strcmp(plugin_id, chord_memory::desc.id) == 0)
+    if (strcmp(plugin_id, chord_memory::ConduitChordMemoryConfig::getDescription()->id) == 0)
     {
         strncpy(info->au_subt, "crMm", 5);
         return true;
     }
-    if (strcmp(plugin_id, ring_modulator::desc.id) == 0)
+    if (strcmp(plugin_id, ring_modulator::ConduitRingModulatorConfig::getDescription()->id) == 0)
     {
         strncpy(info->au_subt, "rngM", 5);
         return true;
     }
-    if (strcmp(plugin_id, clap_event_monitor::desc.id) == 0)
+    if (strcmp(plugin_id,
+               clap_event_monitor::ConduitClapEventMonitorConfig::getDescription()->id) == 0)
     {
         strncpy(info->au_subt, "clEv", 5);
         return true;
     }
-    if (strcmp(plugin_id, mts_to_noteexpression::desc.id) == 0)
+    if (strcmp(plugin_id,
+               mts_to_noteexpression::ConduitMTSToNoteExpressionConfig::getDescription()->id) == 0)
     {
         strncpy(info->au_subt, "mtsN", 5);
         return true;
     }
 
-    if (strcmp(plugin_id, midi2_sawsynth::desc.id) == 0)
+    if (strcmp(plugin_id, midi2_sawsynth::ConduitMIDI2SawSynthConfig::getDescription()->id) == 0)
     {
         strncpy(info->au_subt, "m2sn", 5);
         return true;

--- a/src/conduit-clap-entry.cpp
+++ b/src/conduit-clap-entry.cpp
@@ -126,6 +126,7 @@ static bool clap_get_auv2_info(const clap_plugin_factory_as_auv2 *factory, uint3
                                clap_plugin_info_as_auv2_t *info)
 {
     auto desc = clap_get_plugin_descriptor(nullptr, index); // we don't use the factory above
+
     auto plugin_id = desc->id;
 
     info->au_type[0] = 0; // use the features to determine the type

--- a/src/conduit-shared/clap-base-class.h
+++ b/src/conduit-shared/clap-base-class.h
@@ -65,6 +65,17 @@ struct EmptyPatchExtension
 template <typename T, typename TConfig>
 struct ClapBaseClass : public plugHelper_t, sst::clap_juce_shim::EditorProvider
 {
+    using config_t = TConfig;
+
+    ClapBaseClass(const clap_host *host)
+        : plugHelper_t(TConfig::getDescription(), host), uiComms(*this)
+    {
+        dbToLinearTable.init();
+        equalTuningTable.init();
+        twoToXTable.init();
+        guaranteeDocumentsPath();
+    }
+
     ClapBaseClass(const clap_plugin_descriptor *desc, const clap_host *host)
         : plugHelper_t(desc, host), uiComms(*this)
     {

--- a/src/conduit-shared/editor-base.h
+++ b/src/conduit-shared/editor-base.h
@@ -67,8 +67,7 @@ template <typename Content> struct Background : sst::jucegui::components::Window
 template <typename Content> struct EditorBase : juce::Component
 {
     typename Content::UICommunicationBundle &uic;
-    EditorBase(typename Content::UICommunicationBundle &, const std::string &pluginName,
-               const std::string &pluginId);
+    EditorBase(typename Content::UICommunicationBundle &);
     ~EditorBase() = default;
 
     void setContentComponent(std::unique_ptr<juce::Component> c)
@@ -490,10 +489,10 @@ template <typename Content> void Background<Content>::buildBurger()
 }
 
 template <typename Content>
-EditorBase<Content>::EditorBase(typename Content::UICommunicationBundle &u,
-                                const std::string &pluginName, const std::string &pluginId)
-    : uic(u), pluginName(pluginName), pluginId(pluginId)
+EditorBase<Content>::EditorBase(typename Content::UICommunicationBundle &u) : uic(u)
 {
+    pluginName = Content::config_t::getDescription()->name;
+    pluginId = Content::config_t::getDescription()->id;
     container = std::make_unique<Background<Content>>(pluginName, pluginId, *this);
     addAndMakeVisible(*container);
 }

--- a/src/midi2-sawsynth/midi2-sawsynth-editor.cpp
+++ b/src/midi2-sawsynth/midi2-sawsynth-editor.cpp
@@ -73,9 +73,10 @@ struct ConduitMIDI2SawSynthEditor : public jcmp::WindowPanel,
             addAndMakeVisible(*textB);
             textB->setOnCallback([this]() { editor.clearEvents(); });
         }
-        void resized() override {
+        void resized() override
+        {
             noteOnly->widget->setBounds(0, 0, 200, 20);
-            textB->setBounds(0,22, 200, 20);
+            textB->setBounds(0, 22, 200, 20);
         }
         std::unique_ptr<jcad::DiscreteToValueReference<jcmp::ToggleButton, bool>> noteOnly;
         std::unique_ptr<jcmp::TextPushButton> textB;
@@ -352,8 +353,7 @@ std::unique_ptr<juce::Component> ConduitMIDI2SawSynth::createEditor()
     uiComms.refreshUIValues = true;
     auto innards =
         std::make_unique<sst::conduit::midi2_sawsynth::editor::ConduitMIDI2SawSynthEditor>(uiComms);
-    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitMIDI2SawSynth>>(
-        uiComms, desc.name, desc.id);
+    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitMIDI2SawSynth>>(uiComms);
     innards->fixedFace = editor->loadFont("Anonymous_Pro/AnonymousPro-Regular.ttf");
     editor->setContentComponent(std::move(innards));
 

--- a/src/midi2-sawsynth/midi2-sawsynth.cpp
+++ b/src/midi2-sawsynth/midi2-sawsynth.cpp
@@ -32,8 +32,8 @@ namespace sst::conduit::midi2_sawsynth
 {
 const clap_plugin_descriptor *ConduitMIDI2SawSynthConfig::getDescription()
 {
-    const char *features[] = {CLAP_PLUGIN_FEATURE_INSTRUMENT, CLAP_PLUGIN_FEATURE_SYNTHESIZER,
-                              nullptr};
+    static const char *features[] = {CLAP_PLUGIN_FEATURE_INSTRUMENT,
+                                     CLAP_PLUGIN_FEATURE_SYNTHESIZER, nullptr};
     static clap_plugin_descriptor desc = {CLAP_VERSION,
                                           "org.surge-synth-team.conduit.midi2_sawsynth",
                                           "Conduit MIDI2 SawSynth",
@@ -43,7 +43,7 @@ const clap_plugin_descriptor *ConduitMIDI2SawSynthConfig::getDescription()
                                           "",
                                           sst::conduit::build::FullVersionStr,
                                           "The Conduit MIDI2SawSynth is a work in progress",
-                                          features};
+                                          &features[0]};
     return &desc;
 }
 

--- a/src/midi2-sawsynth/midi2-sawsynth.cpp
+++ b/src/midi2-sawsynth/midi2-sawsynth.cpp
@@ -23,23 +23,33 @@
 #include "juce_gui_basics/juce_gui_basics.h"
 #include "version.h"
 
+#include <midi/midi2_channel_voice_message.h>
+#include <midi/channel_voice_message.h>
+#include <midi/universal_packet.h>
+#include "ni-midi-patches.h"
+
 namespace sst::conduit::midi2_sawsynth
 {
-const char *features[] = {CLAP_PLUGIN_FEATURE_INSTRUMENT, CLAP_PLUGIN_FEATURE_SYNTHESIZER, nullptr};
-clap_plugin_descriptor desc = {CLAP_VERSION,
-                               "org.surge-synth-team.conduit.midi2_sawsynth",
-                               "Conduit MIDI2 SawSynth",
-                               "Surge Synth Team",
-                               "https://surge-synth-team.org",
-                               "",
-                               "",
-                               sst::conduit::build::FullVersionStr,
-                               "The Conduit MIDI2SawSynth is a work in progress",
-                               features};
+const clap_plugin_descriptor *ConduitMIDI2SawSynthConfig::getDescription()
+{
+    const char *features[] = {CLAP_PLUGIN_FEATURE_INSTRUMENT, CLAP_PLUGIN_FEATURE_SYNTHESIZER,
+                              nullptr};
+    static clap_plugin_descriptor desc = {CLAP_VERSION,
+                                          "org.surge-synth-team.conduit.midi2_sawsynth",
+                                          "Conduit MIDI2 SawSynth",
+                                          "Surge Synth Team",
+                                          "https://surge-synth-team.org",
+                                          "",
+                                          "",
+                                          sst::conduit::build::FullVersionStr,
+                                          "The Conduit MIDI2SawSynth is a work in progress",
+                                          features};
+    return &desc;
+}
 
 ConduitMIDI2SawSynth::ConduitMIDI2SawSynth(const clap_host *host)
-    : sst::conduit::shared::ClapBaseClass<ConduitMIDI2SawSynth, ConduitMIDI2SawSynthConfig>(&desc,
-                                                                                            host)
+    : sst::conduit::shared::ClapBaseClass<ConduitMIDI2SawSynth, ConduitMIDI2SawSynthConfig>(host),
+      voiceManager(*this)
 {
     auto autoFlag = CLAP_PARAM_IS_AUTOMATABLE;
     auto steppedFlag = autoFlag | CLAP_PARAM_IS_STEPPED;
@@ -120,7 +130,90 @@ clap_process_status ConduitMIDI2SawSynth::process(const clap_process *process) n
 
         if (et->type == CLAP_EVENT_MIDI2)
         {
-            // auto m2e = reinterpret_cast<const clap_event_midi2 *>(et);
+            auto m2e = reinterpret_cast<const clap_event_midi2 *>(et);
+            auto pk =
+                midi::universal_packet(m2e->data[0], m2e->data[1], m2e->data[2], m2e->data[3]);
+
+            if (pk.type() == midi::packet_type::midi2_channel_voice)
+            {
+                if (midi::is_note_on_message(pk))
+                {
+                    // port channel key noteid velocity retune
+                    voiceManager.processNoteOnEvent(
+                        m2e->port_index, pk.channel(), midi::get_note_pitch(pk).value,
+                        midi::get_note_nr(pk), midi::get_note_velocity(pk).as_float(), 0);
+                }
+#if 0
+                else if (midi::is_note_off_message(pk))
+                {
+                    oss << "note off "
+                        << " nr=" << (int)midi::get_note_nr(pk)
+                        << " pt=" << midi::get_note_pitch(pk).as_float()
+                        << " vel=" << midi::get_note_velocity(pk).as_float();
+
+                    for (int i = 0; i < 4; ++i)
+                        oss << std::hex << " " << (uint32_t)m2e->data[i] << std::dec;
+                }
+                else if (midi::is_channel_pressure_message(pk))
+                {
+                    oss << "channel pressure "
+                        << midi::get_channel_pressure_value(pk).as_float();
+                }
+                else if (midi::is_poly_pressure_message(pk))
+                {
+                    oss << "poly pressure " << midi::get_poly_pressure_value(pk).as_float()
+                        << std::dec << " n=" << (int)midi::get_note_nr(pk) << " "
+                        << " " << std::hex << m2e->data[0] << " " << m2e->data[1] << " "
+                        << m2e->data[2] << " " << m2e->data[3] << " ";
+                }
+                else if (midi::is_channel_pitch_bend_message(pk))
+                {
+                    oss << "channel bend " << midi::get_channel_pitch_bend_value(pk).as_float()
+                        << std::endl;
+                }
+                else if (midi::is_control_change_message(pk))
+                {
+                    oss << "control change " << (int)midi::get_controller_nr(pk) << " "
+                        << midi::get_controller_value(pk).as_float() << std::endl;
+                }
+                else if (midi::is_midi2_registered_per_note_controller_message(pk))
+                {
+                    oss << "registered per note controller n=" << std::dec
+                        << (int)midi::get_note_nr(pk) << " ct=" << std::hex
+                        << (int)midi::get_midi2_per_note_controller_index(pk)
+                        << " val=" << midi::get_controller_value(pk).as_float() << std::endl;
+                }
+                else if (midi::is_midi2_per_note_pitch_bend_message(pk))
+                {
+                    oss << "note pitch bend n=" << std::dec << (int)midi::get_note_nr(pk)
+                        << " val=" << midi::get_controller_value(pk).as_float() << std::endl;
+                }
+                else if (midi::is_midi2_registered_controller_message(pk))
+                {
+                    oss << "registered controller"
+                        << " ct=" << std::hex
+                        << (int)midi::get_midi2_per_note_controller_index(pk);
+                    if (midi::get_midi2_per_note_controller_index(pk) == 0x7)
+                    {
+                        oss << " pitch bend config=";
+                        auto cf = midi::pitch_7_25(m2e->data[1]);
+                        oss << cf.as_float() << " cents";
+                    }
+                }
+                else
+                {
+                    oss << "Unknown " << std::hex << "type=" << (int)pk.type()
+                        << " group=" << (int)pk.group() << " stat=" << (int)pk.status() << " "
+                        << m2e->data[0] << " " << m2e->data[1] << " " << m2e->data[2] << " "
+                        << m2e->data[3] << " ";
+                }
+            }
+            else
+            {
+                oss << "unknown pktype=" << (int)pk.type() << std::endl;
+            }
+#endif
+            }
         }
     }
 

--- a/src/mts-to-noteexpression/mts-to-noteexpression-editor.cpp
+++ b/src/mts-to-noteexpression/mts-to-noteexpression-editor.cpp
@@ -206,8 +206,8 @@ std::unique_ptr<juce::Component> ConduitMTSToNoteExpression::createEditor()
     uiComms.refreshUIValues = true;
     auto innards = std::make_unique<
         sst::conduit::mts_to_noteexpression::editor::ConduitMTSToNoteExpressionEditor>(uiComms);
-    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitMTSToNoteExpression>>(
-        uiComms, desc.name, desc.id);
+    auto editor =
+        std::make_unique<conduit::shared::EditorBase<ConduitMTSToNoteExpression>>(uiComms);
     innards->fixedFace = editor->loadFont("Anonymous_Pro/AnonymousPro-Regular.ttf");
     editor->setContentComponent(std::move(innards));
 

--- a/src/mts-to-noteexpression/mts-to-noteexpression.cpp
+++ b/src/mts-to-noteexpression/mts-to-noteexpression.cpp
@@ -29,7 +29,8 @@ namespace sst::conduit::mts_to_noteexpression
 {
 const clap_plugin_descriptor *ConduitMTSToNoteExpressionConfig::getDescription()
 {
-    const char *features[] = {CLAP_PLUGIN_FEATURE_NOTE_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
+    static const char *features[] = {CLAP_PLUGIN_FEATURE_NOTE_EFFECT, CLAP_PLUGIN_FEATURE_DELAY,
+                                     nullptr};
     static clap_plugin_descriptor desc = {CLAP_VERSION,
                                           "org.surge-synth-team.conduit.mts-to-noteexpression",
                                           "Conduit MTS to Note Expression Adapter",
@@ -39,7 +40,7 @@ const clap_plugin_descriptor *ConduitMTSToNoteExpressionConfig::getDescription()
                                           "",
                                           sst::conduit::build::FullVersionStr,
                                           "The Conduit ClapEventMonitor is a work in progress",
-                                          features};
+                                          &features[0]};
     return &desc;
 }
 

--- a/src/mts-to-noteexpression/mts-to-noteexpression.cpp
+++ b/src/mts-to-noteexpression/mts-to-noteexpression.cpp
@@ -27,21 +27,25 @@
 
 namespace sst::conduit::mts_to_noteexpression
 {
-const char *features[] = {CLAP_PLUGIN_FEATURE_NOTE_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
-clap_plugin_descriptor desc = {CLAP_VERSION,
-                               "org.surge-synth-team.conduit.mts-to-noteexpression",
-                               "Conduit MTS to Note Expression Adapter",
-                               "Surge Synth Team",
-                               "https://surge-synth-team.org",
-                               "",
-                               "",
-                               sst::conduit::build::FullVersionStr,
-                               "The Conduit ClapEventMonitor is a work in progress",
-                               features};
+const clap_plugin_descriptor *ConduitMTSToNoteExpressionConfig::getDescription()
+{
+    const char *features[] = {CLAP_PLUGIN_FEATURE_NOTE_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
+    static clap_plugin_descriptor desc = {CLAP_VERSION,
+                                          "org.surge-synth-team.conduit.mts-to-noteexpression",
+                                          "Conduit MTS to Note Expression Adapter",
+                                          "Surge Synth Team",
+                                          "https://surge-synth-team.org",
+                                          "",
+                                          "",
+                                          sst::conduit::build::FullVersionStr,
+                                          "The Conduit ClapEventMonitor is a work in progress",
+                                          features};
+    return &desc;
+}
 
 ConduitMTSToNoteExpression::ConduitMTSToNoteExpression(const clap_host *host)
     : sst::conduit::shared::ClapBaseClass<ConduitMTSToNoteExpression,
-                                          ConduitMTSToNoteExpressionConfig>(&desc, host)
+                                          ConduitMTSToNoteExpressionConfig>(host)
 {
     mtsClient = MTS_RegisterClient();
 

--- a/src/mts-to-noteexpression/mts-to-noteexpression.h
+++ b/src/mts-to-noteexpression/mts-to-noteexpression.h
@@ -38,8 +38,6 @@ struct MTSClient;
 
 namespace sst::conduit::mts_to_noteexpression
 {
-
-extern clap_plugin_descriptor desc;
 static constexpr int nParams = 2;
 
 struct ConduitMTSToNoteExpressionConfig
@@ -59,7 +57,7 @@ struct ConduitMTSToNoteExpressionConfig
         std::atomic<int32_t> noteRemainingUpdate{0};
     };
 
-    static clap_plugin_descriptor *getDescription() { return &desc; }
+    static const clap_plugin_descriptor *getDescription();
 };
 
 struct ConduitMTSToNoteExpression

--- a/src/polymetric-delay/polymetric-delay-editor.cpp
+++ b/src/polymetric-delay/polymetric-delay-editor.cpp
@@ -339,8 +339,7 @@ std::unique_ptr<juce::Component> ConduitPolymetricDelay::createEditor()
     auto innards =
         std::make_unique<sst::conduit::polymetric_delay::editor::ConduitPolymetricDelayEditor>(
             uiComms);
-    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitPolymetricDelay>>(
-        uiComms, desc.name, desc.id);
+    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitPolymetricDelay>>(uiComms);
     editor->setContentComponent(std::move(innards));
 
     uiComms.refreshUIValues = true;

--- a/src/polymetric-delay/polymetric-delay.cpp
+++ b/src/polymetric-delay/polymetric-delay.cpp
@@ -23,23 +23,33 @@
 #include "version.h"
 #include "sst/basic-blocks/dsp/PanLaws.h"
 
+struct LogOnCreate
+{
+    LogOnCreate() { CNDOUT << "Created instance of LogOnCreate" << std::endl; }
+};
+LogOnCreate logit;
+
 namespace sst::conduit::polymetric_delay
 {
-const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
-clap_plugin_descriptor desc = {CLAP_VERSION,
-                               "org.surge-synth-team.conduit.polymetric-delay",
-                               "Conduit Polymetric Delay",
-                               "Surge Synth Team",
-                               "https://surge-synth-team.org",
-                               "",
-                               "",
-                               sst::conduit::build::FullVersionStr,
-                               "The Conduit Polymetric Delay is a work in progress",
-                               features};
+const clap_plugin_descriptor *ConduitPolymetricDelayConfig::getDescription()
+{
+    const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
+    static clap_plugin_descriptor desc = {CLAP_VERSION,
+                                          "org.surge-synth-team.conduit.polymetric-delay",
+                                          "Conduit Polymetric Delay",
+                                          "Surge Synth Team",
+                                          "https://surge-synth-team.org",
+                                          "",
+                                          "",
+                                          sst::conduit::build::FullVersionStr,
+                                          "The Conduit Polymetric Delay is a work in progress",
+                                          features};
+    return &desc;
+}
 
 ConduitPolymetricDelay::ConduitPolymetricDelay(const clap_host *host)
     : sst::conduit::shared::ClapBaseClass<ConduitPolymetricDelay, ConduitPolymetricDelayConfig>(
-          &desc, host)
+          host)
 {
     auto autoFlag = CLAP_PARAM_IS_AUTOMATABLE;
     auto modFlag = autoFlag | CLAP_PARAM_IS_MODULATABLE;

--- a/src/polymetric-delay/polymetric-delay.cpp
+++ b/src/polymetric-delay/polymetric-delay.cpp
@@ -23,17 +23,12 @@
 #include "version.h"
 #include "sst/basic-blocks/dsp/PanLaws.h"
 
-struct LogOnCreate
-{
-    LogOnCreate() { CNDOUT << "Created instance of LogOnCreate" << std::endl; }
-};
-LogOnCreate logit;
-
 namespace sst::conduit::polymetric_delay
 {
 const clap_plugin_descriptor *ConduitPolymetricDelayConfig::getDescription()
 {
-    const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
+    static const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_DELAY,
+                                     nullptr};
     static clap_plugin_descriptor desc = {CLAP_VERSION,
                                           "org.surge-synth-team.conduit.polymetric-delay",
                                           "Conduit Polymetric Delay",
@@ -43,7 +38,7 @@ const clap_plugin_descriptor *ConduitPolymetricDelayConfig::getDescription()
                                           "",
                                           sst::conduit::build::FullVersionStr,
                                           "The Conduit Polymetric Delay is a work in progress",
-                                          features};
+                                          &features[0]};
     return &desc;
 }
 

--- a/src/polymetric-delay/polymetric-delay.h
+++ b/src/polymetric-delay/polymetric-delay.h
@@ -45,7 +45,6 @@
 namespace sst::conduit::polymetric_delay
 {
 
-extern clap_plugin_descriptor desc;
 static constexpr int nParams = 45;
 
 struct ConduitPolymetricDelayConfig
@@ -70,7 +69,7 @@ struct ConduitPolymetricDelayConfig
         std::atomic<float> inVu[2], outVu[2], tapVu[4][2];
     };
 
-    static clap_plugin_descriptor *getDescription() { return &desc; }
+    static const clap_plugin_descriptor *getDescription();
 };
 
 struct ConduitPolymetricDelay

--- a/src/polysynth/polysynth-editor.cpp
+++ b/src/polysynth/polysynth-editor.cpp
@@ -696,7 +696,6 @@ ModMatrixPanel::ModMatrixPanel(sst::conduit::polysynth::editor::uicomm_t &p,
 {
     auto content = std::make_unique<Content>();
 
-    CNDOUT << "Constructing ModMatrix Panel" << std::endl;
     auto v = uic.getAllParamDescriptions();
     for (auto &pd : v)
     {
@@ -717,6 +716,7 @@ ModMatrixPanel::ModMatrixPanel(sst::conduit::polysynth::editor::uicomm_t &p,
         sourceName[pd.first] = pd.second.first;
     }
 
+#if DEBUG_MATRIX_MENUS
     for (const auto &[g, m] : targetMenu)
     {
         CNDOUT << "T -- " << g << std::endl;
@@ -734,6 +734,7 @@ ModMatrixPanel::ModMatrixPanel(sst::conduit::polysynth::editor::uicomm_t &p,
             CNDOUT << "S     |-- " << n << " (" << id << ")" << std::endl;
         }
     }
+#endif
 
     for (auto i = 0U; i < content->modRows.size(); ++i)
     {
@@ -1030,8 +1031,7 @@ std::unique_ptr<juce::Component> ConduitPolysynth::createEditor()
     uiComms.refreshUIValues = true;
     auto innards =
         std::make_unique<sst::conduit::polysynth::editor::ConduitPolysynthEditor>(uiComms);
-    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitPolysynth>>(
-        uiComms, desc.name, desc.id);
+    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitPolysynth>>(uiComms);
     editor->setContentComponent(std::move(innards));
 
     return editor;

--- a/src/polysynth/polysynth.cpp
+++ b/src/polysynth/polysynth.cpp
@@ -53,7 +53,7 @@ const clap_plugin_descriptor *ConduitPolysynthConfig::getDescription()
                                           "",
                                           sst::conduit::build::FullVersionStr,
                                           "The Conduit Polysynth is a work in progress",
-                                          features};
+                                          &features[0]};
     return &desc;
 }
 

--- a/src/polysynth/polysynth.cpp
+++ b/src/polysynth/polysynth.cpp
@@ -40,20 +40,25 @@
 namespace sst::conduit::polysynth
 {
 
-const char *features[] = {CLAP_PLUGIN_FEATURE_INSTRUMENT, CLAP_PLUGIN_FEATURE_SYNTHESIZER, nullptr};
-clap_plugin_descriptor desc = {CLAP_VERSION,
-                               "org.surge-synth-team.conduit.polysynth",
-                               "Conduit Polysynth",
-                               "Surge Synth Team",
-                               "https://surge-synth-team.org",
-                               "",
-                               "",
-                               sst::conduit::build::FullVersionStr,
-                               "The Conduit Polysynth is a work in progress",
-                               features};
+const clap_plugin_descriptor *ConduitPolysynthConfig::getDescription()
+{
+    static const char *features[] = {CLAP_PLUGIN_FEATURE_INSTRUMENT,
+                                     CLAP_PLUGIN_FEATURE_SYNTHESIZER, nullptr};
+    static clap_plugin_descriptor desc = {CLAP_VERSION,
+                                          "org.surge-synth-team.conduit.polysynth",
+                                          "Conduit Polysynth",
+                                          "Surge Synth Team",
+                                          "https://surge-synth-team.org",
+                                          "",
+                                          "",
+                                          sst::conduit::build::FullVersionStr,
+                                          "The Conduit Polysynth is a work in progress",
+                                          features};
+    return &desc;
+}
 
 ConduitPolysynth::ConduitPolysynth(const clap_host *host)
-    : sst::conduit::shared::ClapBaseClass<ConduitPolysynth, ConduitPolysynthConfig>(&desc, host),
+    : sst::conduit::shared::ClapBaseClass<ConduitPolysynth, ConduitPolysynthConfig>(host),
       gen((size_t)this), urd(0.f, 1.f), hr_dn(6, true), voiceManager(*this),
       voices{sst::cpputils::make_array<PolysynthVoice, max_voices>(*this)}
 {

--- a/src/polysynth/polysynth.h
+++ b/src/polysynth/polysynth.h
@@ -57,7 +57,6 @@ namespace sst::conduit::polysynth
  * This static (defined in the cpp file) allows us to present a name, feature set,
  * url etc... and is consumed by clap-saw-demo-pluginentry.cpp
  */
-extern clap_plugin_descriptor desc;
 static constexpr int nParams{72};
 
 struct ModMatrixConfig;
@@ -94,7 +93,7 @@ struct ConduitPolysynthConfig
         void populateMatrixView(const std::unique_ptr<ModMatrixConfig> &);
     };
 
-    static clap_plugin_descriptor *getDescription() { return &desc; }
+    static const clap_plugin_descriptor *getDescription();
 
     struct SpecializedMessage
     {
@@ -331,6 +330,18 @@ struct ConduitPolysynth
     std::function<void(PolysynthVoice *)> voiceEndCallback;
     void setVoiceEndCallback(std::function<void(PolysynthVoice *)> f) { voiceEndCallback = f; }
 
+    constexpr int32_t voiceCountForInitializationAction(uint16_t port, uint16_t channel,
+                                                        uint16_t key, int32_t noteId)
+    {
+        return 1;
+    }
+    int32_t initializeMultipleVoices(
+        std::array<PolysynthVoice *, VMConfig::maxVoiceCount> &voiceInitWorkingBuffer,
+        uint16_t port, uint16_t channel, uint16_t key, int32_t noteId, float velocity, float retune)
+    {
+        voiceInitWorkingBuffer[0] = initializeVoice(port, channel, key, noteId, velocity, retune);
+        return 1;
+    }
     PolysynthVoice *initializeVoice(uint16_t port, uint16_t channel, uint16_t key, int32_t noteId,
                                     float velocity, float retune);
     void releaseVoice(PolysynthVoice *v, float velocity);

--- a/src/ring-modulator/ring-modulator-editor.cpp
+++ b/src/ring-modulator/ring-modulator-editor.cpp
@@ -174,8 +174,7 @@ std::unique_ptr<juce::Component> ConduitRingModulator::createEditor()
     uiComms.refreshUIValues = true;
     auto innards =
         std::make_unique<sst::conduit::ring_modulator::editor::ConduitRingModulatorEditor>(uiComms);
-    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitRingModulator>>(
-        uiComms, desc.name, desc.id);
+    auto editor = std::make_unique<conduit::shared::EditorBase<ConduitRingModulator>>(uiComms);
     editor->setContentComponent(std::move(innards));
 
     return editor;

--- a/src/ring-modulator/ring-modulator.cpp
+++ b/src/ring-modulator/ring-modulator.cpp
@@ -29,21 +29,25 @@ namespace sst::conduit::ring_modulator
 
 namespace mech = sst::basic_blocks::mechanics;
 
-const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
-clap_plugin_descriptor desc = {CLAP_VERSION,
-                               "org.surge-synth-team.conduit.ring-modulator",
-                               "Conduit Ring Modulator",
-                               "Surge Synth Team",
-                               "https://surge-synth-team.org",
-                               "",
-                               "",
-                               sst::conduit::build::FullVersionStr,
-                               "The Conduit RingModulator is a work in progress",
-                               features};
+const clap_plugin_descriptor *ConduitRingModulatorConfig::getDescription()
+{
+
+    const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
+    static clap_plugin_descriptor desc = {CLAP_VERSION,
+                                          "org.surge-synth-team.conduit.ring-modulator",
+                                          "Conduit Ring Modulator",
+                                          "Surge Synth Team",
+                                          "https://surge-synth-team.org",
+                                          "",
+                                          "",
+                                          sst::conduit::build::FullVersionStr,
+                                          "The Conduit RingModulator is a work in progress",
+                                          features};
+    return &desc;
+}
 
 ConduitRingModulator::ConduitRingModulator(const clap_host *host)
-    : sst::conduit::shared::ClapBaseClass<ConduitRingModulator, ConduitRingModulatorConfig>(&desc,
-                                                                                            host),
+    : sst::conduit::shared::ClapBaseClass<ConduitRingModulator, ConduitRingModulatorConfig>(host),
       hr_up(6, true), hr_scup(6, true), hr_down(6, true)
 {
     auto autoFlag = CLAP_PARAM_IS_AUTOMATABLE;

--- a/src/ring-modulator/ring-modulator.cpp
+++ b/src/ring-modulator/ring-modulator.cpp
@@ -32,7 +32,8 @@ namespace mech = sst::basic_blocks::mechanics;
 const clap_plugin_descriptor *ConduitRingModulatorConfig::getDescription()
 {
 
-    const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_DELAY, nullptr};
+    static const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_DELAY,
+                                     nullptr};
     static clap_plugin_descriptor desc = {CLAP_VERSION,
                                           "org.surge-synth-team.conduit.ring-modulator",
                                           "Conduit Ring Modulator",
@@ -42,7 +43,7 @@ const clap_plugin_descriptor *ConduitRingModulatorConfig::getDescription()
                                           "",
                                           sst::conduit::build::FullVersionStr,
                                           "The Conduit RingModulator is a work in progress",
-                                          features};
+                                          &features[0]};
     return &desc;
 }
 

--- a/src/ring-modulator/ring-modulator.h
+++ b/src/ring-modulator/ring-modulator.h
@@ -38,7 +38,6 @@
 namespace sst::conduit::ring_modulator
 {
 
-extern clap_plugin_descriptor desc;
 static constexpr int nParams = 4;
 
 struct ConduitRingModulatorConfig
@@ -53,7 +52,7 @@ struct ConduitRingModulatorConfig
         std::atomic<bool> isProcessing{false};
     };
 
-    static clap_plugin_descriptor *getDescription() { return &desc; }
+    static const clap_plugin_descriptor *getDescription();
 };
 
 struct ConduitRingModulator


### PR DESCRIPTION
- MOve desc to a function static rather than a global static to avoid annoying auv2 link/load/order problem.
- Fill out the voice manager to have multi-voice-per-note features
- Continue pushing on midi2, including having a voice manager, but still no voices or audio