### PR TITLE
Fix a windows crash on exit

### DIFF
--- a/src/conduit-shared/editor-base.h
+++ b/src/conduit-shared/editor-base.h
@@ -188,6 +188,7 @@ template <typename T, typename TEd> struct EditorCommunicationsHandler
     ~EditorCommunicationsHandler()
     {
         assert(!idleTimer); // hit this and you never called stop or start
+        assert(idleHandlers.empty());
     }
 
     std::unordered_map<std::string, std::function<void()>> idleHandlers;


### PR DESCRIPTION
from jucegui being partially implemented in the shutdown path.

Closes #72