### PR TITLE
Fix event data copying

### DIFF
--- a/src/clap-event-monitor/clap-event-monitor-editor.cpp
+++ b/src/clap-event-monitor/clap-event-monitor-editor.cpp
@@ -276,6 +276,7 @@ struct ConduitClapEventMonitorEditor : public sst::jucegui::accessibility::Ignor
             case CLAP_EVENT_NOTE_EXPRESSION:
             {
                 std::ostringstream oss;
+                oss << std::fixed << std::setprecision(3);
                 oss << "CLAP_EVENT_NOTE_EXPRESSION_";
                 auto nexp = reinterpret_cast<const clap_event_note_expression_t *>(ev);
                 switch (nexp->expression_id)

--- a/src/clap-event-monitor/clap-event-monitor-editor.cpp
+++ b/src/clap-event-monitor/clap-event-monitor-editor.cpp
@@ -274,8 +274,40 @@ struct ConduitClapEventMonitorEditor : public sst::jucegui::accessibility::Ignor
             }
             break;
             case CLAP_EVENT_NOTE_EXPRESSION:
-                return "CLAP_EVENT_NOTE_EXPRESSION";
-
+            {
+                std::ostringstream oss;
+                oss << "CLAP_EVENT_NOTE_EXPRESSION_";
+                auto nexp = reinterpret_cast<const clap_event_note_expression_t *>(ev);
+                switch (nexp->expression_id)
+                {
+                case CLAP_NOTE_EXPRESSION_BRIGHTNESS:
+                    oss << "BRIGHTNESS";
+                    break;
+                case CLAP_NOTE_EXPRESSION_EXPRESSION:
+                    oss << "EXPRESSION";
+                    break;
+                case CLAP_NOTE_EXPRESSION_PAN:
+                    oss << "PAN";
+                    break;
+                case CLAP_NOTE_EXPRESSION_PRESSURE:
+                    oss << "PRESSURE";
+                    break;
+                case CLAP_NOTE_EXPRESSION_TUNING:
+                    oss << "TUNING";
+                    break;
+                case CLAP_NOTE_EXPRESSION_VIBRATO:
+                    oss << "VIBRATO";
+                    break;
+                case CLAP_NOTE_EXPRESSION_VOLUME:
+                    oss << "VOLUME";
+                    break;
+                default:
+                    oss << "UNKNOWN";
+                }
+                oss << " " << nexp->value;
+                return oss.str();
+            }
+            break;
             case CLAP_EVENT_PARAM_VALUE:
                 return "CLAP_EVENT_PARAM_VALUE";
             case CLAP_EVENT_PARAM_MOD:

--- a/src/clap-event-monitor/clap-event-monitor.h
+++ b/src/clap-event-monitor/clap-event-monitor.h
@@ -58,7 +58,7 @@ struct ConduitClapEventMonitorConfig
             void assign(const clap_event_header_t *e)
             {
                 assert(e->size < maxEventSize);
-                memcpy(data, e, std::max(e->size, maxEventSize));
+                memcpy(data, e, std::min(e->size, maxEventSize));
             }
 
             const clap_event_header_t *view() const


### PR DESCRIPTION
std::min should be used instead of std::max so as to not attempt reading invalid memory from the host.